### PR TITLE
Call fetch() explictly with HTTPS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Node oAuth2 Example</title>
+        <title>Go OAuth2 Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- <link rel="stylesheet" type="text/css" media="screen" href="main.css" /> -->
         <!-- <script src="main.js"></script> -->

--- a/public/welcome.html
+++ b/public/welcome.html
@@ -18,7 +18,7 @@
 	const token = query.split('access_token=')[1]
 
 	// Call the user info API using the fetch browser library
-	fetch('//api.github.com/user', {
+	fetch('https://api.github.com/user', {
 			headers: {
 				// Include the token in the Authorization header
 				Authorization: 'token ' + token


### PR DESCRIPTION
Explicitly added 'HTTPS' in the call to fetch(), since GitHub's API requires it, and will throw a JavaScript error if localhost isn't using a secure self-signed certificate.

(And also changed "node" to "Go"). ;)